### PR TITLE
New dates

### DIFF
--- a/2026/web/content/_index.md
+++ b/2026/web/content/_index.md
@@ -22,8 +22,8 @@ Submit your **2-page position paper** via [HotCRP][hotcrp].
 Important dates:
 
 - Paper submission: **January 31, 2026**
-- Author Notification: **February 20, 2026**
-- Workshop: **March 22 or 23, 2026**
+- Author Notification: **February 17, 2026**
+- Workshop: **March 23, 2026**
 
 ### Overview
 


### PR DESCRIPTION
The ASPLOS workshop people would like our notifications to happen on or before February 17. Also, they assigned us Sunday (3/23) for the workshop day, so that's resolved now.